### PR TITLE
Minimap strata issue

### DIFF
--- a/SexyMap.lua
+++ b/SexyMap.lua
@@ -482,6 +482,7 @@ function mod:SetupMap()
 		Minimap:ClearAllPoints()
 		Minimap:SetParent(UIParent)
 		Minimap:SetPoint(mod.db.point, UIParent, mod.db.relpoint, mod.db.x, mod.db.y)
+		Minimap:SetFrameStrata("LOW")
 	end
 	self.SetupMap = nil
 end


### PR DESCRIPTION
Hi,

I noticed that the strata of my minimap was set to `MEDIUM` (tested in WoW 8.0.1 by running the following from the ingame console: `/script print(Minimap:GetFrameStrata())`). This causes it to overlap with other stuff. Now according to the source code, I believe it is intended to be `LOW` (SexyMap.lua:470). This commit should fix the issue.