### PR TITLE
Buttons: show buttons when changing drag radius

### DIFF
--- a/Buttons.lua
+++ b/Buttons.lua
@@ -381,11 +381,7 @@ do
 		end
 	end
 
-	local OnEnter = function()
-		mod:ShowAllButtons()
-	end
-
-	local OnLeave = function()
+	function mod:HideAllButtons()
 		if not mod.db.controlVisibility or moving then return end
 		local focus = GetMouseFocus() -- Minimap or Minimap icons including nil checks to compensate for other addons
 		if focus and not focus:IsForbidden() and ((focus:GetName() == "Minimap") or (focus:GetParent() and focus:GetParent():GetName() and focus:GetParent():GetName():find("Mini[Mm]ap"))) then
@@ -406,6 +402,14 @@ do
 				end
 			end
 		end
+	end
+
+	local OnEnter = function()
+		mod:ShowAllButtons()
+	end
+
+	local OnLeave = function()
+		mod:HideAllButtons()
 	end
 
 	local hideFrame = CreateFrame("Frame") -- Dummy frame we use for hiding buttons to prevent other addons re-showing them

--- a/Buttons.lua
+++ b/Buttons.lua
@@ -603,6 +603,8 @@ do
 	function mod:UpdateDraggables(frame)
 		if not mod.db.allowDragging then return end
 
+		mod:ShowAllButtons()
+
 		if frame then
 			local x, y = frame:GetCenter()
 			local name = namesCompatForDF[frame] or frame:GetName()
@@ -624,6 +626,9 @@ do
 				end
 			end
 		end
+
+		mod:HideAllButtons()
+
 	end
 end
 

--- a/Buttons.lua
+++ b/Buttons.lua
@@ -362,7 +362,7 @@ do
 		end
 	end
 
-	local OnEnter = function()
+	function mod:ShowAllButtons()
 		if not mod.db.controlVisibility or fadeStop or moving then return end
 
 		for i = 1, #animFrames do
@@ -380,6 +380,11 @@ do
 			end
 		end
 	end
+
+	local OnEnter = function()
+		mod:ShowAllButtons()
+	end
+
 	local OnLeave = function()
 		if not mod.db.controlVisibility or moving then return end
 		local focus = GetMouseFocus() -- Minimap or Minimap icons including nil checks to compensate for other addons


### PR DESCRIPTION
Note: this is my first attempt at WoW & Lua coding, so I'm not super-familiar with its scopes.

This PR adds code to show mini-map buttons when changing the drag radius:

![wow show buttons when changing drag radius 2](https://user-images.githubusercontent.com/85714/205761352-981dcb18-7914-46dd-9311-351cb1de3713.gif)
