### PR TITLE
Buttons: allow scaling independently from overall map scale

### DIFF
--- a/Buttons.lua
+++ b/Buttons.lua
@@ -117,8 +117,27 @@ local options = {
 				mod:UpdateDraggables()
 			end
 		},
-		visSpacer = {
+		scale = {
 			order = 104,
+			type = "range",
+			name = L["Scale"],
+			min = 0.7,
+			max = 2.5,
+			step = 0.01,
+			bigStep = 0.01,
+			disabled = function()
+				return not mod.db.allowDragging
+			end,
+			get = function(info)
+				return mod.db.buttonScale or mod:GetMapScale()
+			end,
+			set = function(info, v)
+				mod.db.buttonScale = v
+				mod:UpdateDraggables()
+			end,
+		},
+		visSpacer = {
+			order = 105,
 			type = "header",
 			name = L["Visibility"],
 		},
@@ -127,7 +146,7 @@ local options = {
 			name = L["Let SexyMap control button visibility"],
 			desc = L["Turn this off if you want another mod to handle which buttons are visible on the minimap."],
 			width = "full",
-			order = 105,
+			order = 106,
 			get = function()
 				return mod.db.controlVisibility
 			end,
@@ -511,7 +530,7 @@ do
 end
 
 --------------------------------------------------------------------------------
--- Dragging
+-- Dragging and scaling
 --
 
 local dragFrame = CreateFrame("Frame")
@@ -532,6 +551,16 @@ do
 	local setPosition = function(frame, angle)
 		local radius = (Minimap:GetWidth() / 2) + mod.db.radius
 		local bx, by = sm.shapes:GetPosition(angle, radius)
+
+		-- adjust button size for custom button scale
+		do
+			local buttonScale = mod.db.buttonScale
+			local mapScale = mod:GetMapScale()
+
+			if buttonScale and buttonScale ~= mapScale then
+				frame:SetScale(buttonScale / mapScale)
+			end
+		end
 
 		frame:ClearAllPoints()
 		frame:SetPoint("CENTER", Minimap, "CENTER", bx, by)
@@ -674,6 +703,11 @@ do
 		CheckCalendar()
 
 		mod.StartFrameGrab = nil
+	end
+
+	function mod:GetMapScale()
+		-- see SexyMap.lua for where .scale is set
+		return sm.core.db.scale or (MinimapNorthTag and 1 or 1.1)
 	end
 end
 


### PR DESCRIPTION
Allow buttons to be scaled independently from the overall map scale:

![wow scaling buttons](https://user-images.githubusercontent.com/85714/205773821-20f88620-f890-472a-9478-db3e03baaaa4.gif)

As the gif shows, there is a small bug with buttons that haven't been moved before: scaling them can cause them to move, but I don't feel this matters, since (as the gif shows), they can then be moved to where you'd like.  Further scaling/drag radius changes no longer exhibit this issue.

Should address https://github.com/funkydude/SexyMap/issues/10

Note the gif was generated with https://github.com/funkydude/SexyMap/pull/308 already in the file, so that PR should be merged first, please!