### PR TITLE
default to global profile on fresh characters

### DIFF
--- a/SexyMap.lua
+++ b/SexyMap.lua
@@ -353,7 +353,11 @@ function mod:ADDON_LOADED(addon)
 
 		local char = UnitName("player").."-"..GetRealmName()
 		if not SexyMap2DB[char] then
+			if SexyMap2DB.global then
+				SexyMap2DB[char] = "global" -- Default to global profile if it exists
+			else
 			SexyMap2DB[char] = {}
+			end
 		end
 
 		local dbToDispatch

--- a/SexyMap_TBC.lua
+++ b/SexyMap_TBC.lua
@@ -345,7 +345,11 @@ function mod:ADDON_LOADED(addon)
 
 		local char = UnitName("player").."-"..GetRealmName()
 		if not SexyMap2DB[char] then
+			if SexyMap2DB.global then
+				SexyMap2DB[char] = "global" -- Default to global profile if it exists
+			else
 			SexyMap2DB[char] = {}
+			end
 		end
 
 		local dbToDispatch

--- a/SexyMap_Vanilla.lua
+++ b/SexyMap_Vanilla.lua
@@ -366,7 +366,11 @@ function mod:ADDON_LOADED(addon)
 
 		local char = UnitName("player").."-"..GetRealmName()
 		if not SexyMap2DB[char] then
+			if SexyMap2DB.global then
+				SexyMap2DB[char] = "global" -- Default to global profile if it exists
+			else
 			SexyMap2DB[char] = {}
+			end
 		end
 
 		local dbToDispatch

--- a/SexyMap_Wrath.lua
+++ b/SexyMap_Wrath.lua
@@ -353,7 +353,11 @@ function mod:ADDON_LOADED(addon)
 
 		local char = UnitName("player").."-"..GetRealmName()
 		if not SexyMap2DB[char] then
+			if SexyMap2DB.global then
+				SexyMap2DB[char] = "global" -- Default to global profile if it exists
+			else
 			SexyMap2DB[char] = {}
+			end
 		end
 
 		local dbToDispatch


### PR DESCRIPTION
Right now every new character needs to select global profile and reload, even if a global profile is used by the account.  This defaults to global profile if there is one.  Reduces the number of reloads on character creation by one.