### PR TITLE
Fix nil-parent crash in UpdateDraggables on Classic Era 1.15.9

### DIFF
--- a/Buttons.lua
+++ b/Buttons.lua
@@ -560,6 +560,7 @@ local dragFrame = CreateFrame("Frame")
 
 do
 	local getCurrentAngle = function(parent, bx, by)
+		if not parent then return 0 end
 		local mx, my = parent:GetCenter()
 		if not mx or not my or not bx or not by then return 0 end
 		local h, w = (by - my), (bx - mx)
@@ -642,7 +643,7 @@ do
 		if frame then
 			local x, y = frame:GetCenter()
 			local name = buttonNicknames[frame] or frame:GetName()
-			local angle = mod.db.dragPositions[name] or getCurrentAngle(frame:GetParent(), x, y)
+			local angle = mod.db.dragPositions[name] or getCurrentAngle(frame:GetParent() or Minimap, x, y)
 			if angle then
 				setPosition(frame, angle)
 			end

--- a/Buttons_Classic.lua
+++ b/Buttons_Classic.lua
@@ -465,6 +465,7 @@ local dragFrame = CreateFrame("Frame")
 
 do
 	local getCurrentAngle = function(parent, bx, by)
+		if not parent then return 0 end
 		local mx, my = parent:GetCenter()
 		if not mx or not my or not bx or not by then return 0 end
 		local h, w = (by - my), (bx - mx)
@@ -542,7 +543,7 @@ do
 
 		if frame then
 			local x, y = frame:GetCenter()
-			local angle = mod.db.dragPositions[frame:GetName()] or getCurrentAngle(frame:GetParent(), x, y)
+			local angle = mod.db.dragPositions[frame:GetName()] or getCurrentAngle(frame:GetParent() or Minimap, x, y)
 			if angle then
 				setPosition(frame, angle)
 			end

--- a/Buttons_Wrath.lua
+++ b/Buttons_Wrath.lua
@@ -463,6 +463,7 @@ local dragFrame = CreateFrame("Frame")
 
 do
 	local getCurrentAngle = function(parent, bx, by)
+		if not parent then return 0 end
 		local mx, my = parent:GetCenter()
 		if not mx or not my or not bx or not by then return 0 end
 		local h, w = (by - my), (bx - mx)
@@ -540,7 +541,7 @@ do
 
 		if frame then
 			local x, y = frame:GetCenter()
-			local angle = mod.db.dragPositions[frame:GetName()] or getCurrentAngle(frame:GetParent(), x, y)
+			local angle = mod.db.dragPositions[frame:GetName()] or getCurrentAngle(frame:GetParent() or Minimap, x, y)
 			if angle then
 				setPosition(frame, angle)
 			end


### PR DESCRIPTION
## Problem

On WoW Classic Era **1.15.9**, some of the minimap buttons grabbed by SexyMap now have a `nil` parent by the time `UpdateDraggables` runs. `frame:GetParent()` returns `nil`, which is passed straight into `getCurrentAngle`, and the addon errors on `parent:GetCenter()`:

```
Interface/AddOns/SexyMap/Buttons_Classic.lua:468: attempt to index local 'parent' (a nil value)
Stack:
  Buttons_Classic.lua:468: in function <...:467>   -- getCurrentAngle
  Buttons_Classic.lua:545: in function 'UpdateDraggables'
  Buttons_Classic.lua:537: in function 'MakeMovable'
  Buttons_Classic.lua:415: in function 'NewFrame'
  Buttons_Classic.lua:598: in function <...:592>   -- StartFrameGrab
Locals:
  parent=nil
  bx=27.500000
  by=725.500061
```

## Fix

- At the call site, fall back to `Minimap` when a button has no parent. These are all minimap buttons and `setPosition` anchors them relative to `Minimap` anyway, so `Minimap` is the correct reference frame for the angle calculation.
- Add a defensive `if not parent then return 0 end` guard at the top of `getCurrentAngle` so no other code path can reproduce the crash.

Applied consistently to `Buttons.lua`, `Buttons_Classic.lua`, and `Buttons_Wrath.lua` since they share the same code path. The reported/tested crash is the Classic Era one (`Buttons_Classic.lua`, loaded by the Vanilla/TBC TOCs); the other two get the same purely-defensive guard for consistency — it changes nothing when `parent` is non-nil.

Tested in-game on Classic Era 1.15.9: error is gone and minimap buttons position/drag normally.